### PR TITLE
fix: stabilize tasks.md checklist format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .idea/
 .local/
 .claude/
+.skills/

--- a/dist/commands/ArchiveCommand.js
+++ b/dist/commands/ArchiveCommand.js
@@ -209,6 +209,7 @@ class ArchiveCommand extends BaseCommand_1.BaseCommand {
         await services_1.services.fileService.move(targetPath, archivePath);
         await services_1.services.stateManager.writeState(archivePath, nextState);
         await this.updateProposalStatus(archivePath, 'archived');
+        await services_1.services.projectService.rebaseMovedChangeMarkdownLinks(targetPath, archivePath);
         await services_1.services.projectService.rebuildIndex(projectRoot);
         return this.toRelativePath(projectRoot, archivePath);
     }

--- a/dist/commands/NewCommand.js
+++ b/dist/commands/NewCommand.js
@@ -78,6 +78,8 @@ class NewCommand extends BaseCommand_1.BaseCommand {
                 flags,
                 optionalSteps: activatedSteps,
                 documentLanguage,
+                projectRoot: targetDir,
+                documentPath: path.join(featureDir, constants_1.FILE_NAMES.PROPOSAL),
             }));
             await services_1.services.fileService.writeFile(path.join(featureDir, constants_1.FILE_NAMES.TASKS), services_1.services.templateEngine.generateTasksTemplate({
                 feature: featureName,
@@ -87,6 +89,8 @@ class NewCommand extends BaseCommand_1.BaseCommand {
                 flags,
                 optionalSteps: activatedSteps,
                 documentLanguage,
+                projectRoot: targetDir,
+                documentPath: path.join(featureDir, constants_1.FILE_NAMES.TASKS),
             }));
             await services_1.services.fileService.writeFile(path.join(featureDir, constants_1.FILE_NAMES.VERIFICATION), services_1.services.templateEngine.generateVerificationTemplate({
                 feature: featureName,
@@ -96,6 +100,8 @@ class NewCommand extends BaseCommand_1.BaseCommand {
                 flags,
                 optionalSteps: activatedSteps,
                 documentLanguage,
+                projectRoot: targetDir,
+                documentPath: path.join(featureDir, constants_1.FILE_NAMES.VERIFICATION),
             }));
             await services_1.services.fileService.writeFile(path.join(featureDir, constants_1.FILE_NAMES.REVIEW), services_1.services.templateEngine.generateReviewTemplate({
                 feature: featureName,
@@ -105,6 +111,8 @@ class NewCommand extends BaseCommand_1.BaseCommand {
                 flags,
                 optionalSteps: activatedSteps,
                 documentLanguage,
+                projectRoot: targetDir,
+                documentPath: path.join(featureDir, constants_1.FILE_NAMES.REVIEW),
             }));
             await this.writePluginArtifacts(featureDir, activatedSteps);
             this.success(`${placement === constants_1.DIR_NAMES.QUEUED ? 'Queued change' : 'Change'} ${featureName} created at ${featureDir}`);

--- a/dist/services/ProjectService.d.ts
+++ b/dist/services/ProjectService.d.ts
@@ -126,6 +126,7 @@ export declare class ProjectService {
         archivePath: string;
         change: ActiveChangeStatusItem;
     }>;
+    rebaseMovedChangeMarkdownLinks(previousChangePath: string, nextChangePath: string): Promise<void>;
     getFeatureProjectContext(rootDir: string, affects?: string[]): Promise<FeatureProjectContext>;
     getDocsStatus(rootDir: string): Promise<DocsStatus>;
     getSkillsStatus(rootDir: string): Promise<SkillsStatus>;

--- a/dist/services/ProjectService.js
+++ b/dist/services/ProjectService.js
@@ -4545,6 +4545,7 @@ class ProjectService {
 
 
 
+        await this.rebaseMovedChangeMarkdownLinks(resolvedFeaturePath, archivePath);
         await this.rebuildIndex(projectRoot);
 
 
@@ -4593,6 +4594,51 @@ class ProjectService {
 
 
 
+    async rebaseMovedChangeMarkdownLinks(previousChangePath, nextChangePath) {
+        const previousRoot = path_1.default.resolve(previousChangePath);
+        const nextRoot = path_1.default.resolve(nextChangePath);
+        const markdownFiles = [
+            constants_1.FILE_NAMES.PROPOSAL,
+            constants_1.FILE_NAMES.TASKS,
+            constants_1.FILE_NAMES.VERIFICATION,
+            constants_1.FILE_NAMES.REVIEW,
+        ];
+        for (const fileName of markdownFiles) {
+            const nextFilePath = path_1.default.join(nextRoot, fileName);
+            if (!(await this.fileService.exists(nextFilePath))) {
+                continue;
+            }
+            const previousFilePath = path_1.default.join(previousRoot, fileName);
+            const originalContent = await this.fileService.readFile(nextFilePath);
+            const previousDir = path_1.default.dirname(previousFilePath);
+            const nextDir = path_1.default.dirname(nextFilePath);
+            const rewrittenContent = originalContent.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (match, label, rawHref) => {
+                const href = String(rawHref || '').trim();
+                if (!this.isRelativeMarkdownHref(href)) {
+                    return match;
+                }
+                const previousTargetPath = path_1.default.resolve(previousDir, href);
+                if (this.isPathWithin(previousTargetPath, previousRoot)) {
+                    return match;
+                }
+                const rebasedHref = path_1.default.relative(nextDir, previousTargetPath).replace(/\\/g, '/');
+                return `[${label}](${rebasedHref || '.'})`;
+            });
+            if (rewrittenContent !== originalContent) {
+                await this.fileService.writeFile(nextFilePath, rewrittenContent);
+            }
+        }
+    }
+    isRelativeMarkdownHref(href) {
+        return Boolean(href) &&
+            !href.startsWith('#') &&
+            !href.startsWith('//') &&
+            !/^[a-z][a-z0-9+.-]*:/i.test(href);
+    }
+    isPathWithin(targetPath, parentPath) {
+        const relativePath = path_1.default.relative(parentPath, targetPath);
+        return relativePath === '' || (!relativePath.startsWith('..') && !path_1.default.isAbsolute(relativePath));
+    }
     async getFeatureProjectContext(rootDir, affects = []) {
 
 

--- a/dist/services/QueueService.js
+++ b/dist/services/QueueService.js
@@ -77,6 +77,7 @@ class QueueService {
         await this.fileService.writeJSON(statePath, state);
         await this.updateFrontmatterStatus(path_1.default.join(activePath, constants_1.FILE_NAMES.PROPOSAL), 'active');
         await this.updateFrontmatterStatus(path_1.default.join(activePath, constants_1.FILE_NAMES.VERIFICATION), 'verifying');
+        await this.projectService.rebaseMovedChangeMarkdownLinks(queuedPath, activePath);
         const item = await this.buildQueuedChangeStatusItem(rootDir, activePath);
         if (!item) {
             throw new Error(`Activated change state could not be read: ${changeName}`);

--- a/dist/services/TemplateGenerator.js
+++ b/dist/services/TemplateGenerator.js
@@ -63,20 +63,20 @@ optional_steps: [${optionalSteps.map((s) => `"${s}"`).join(', ')}]
         // 添加核心任务
         if (coreRequiredSteps.length > 0) {
             coreRequiredSteps.forEach((step, index) => {
-                content += `- [ ] ${index + 1}. ${step}\n`;
+                content += `- [ ] ${step}\n`;
             });
         }
         else {
-            content += `- [ ] 1. 实现功能\n`;
-            content += `- [ ] 2. 更新文档\n`;
-            content += `- [ ] 3. 更新索引\n`;
-            content += `- [ ] 4. 运行测试\n`;
+            content += `- [ ] 实现功能\n`;
+            content += `- [ ] 更新文档\n`;
+            content += `- [ ] 更新索引\n`;
+            content += `- [ ] 运行测试\n`;
         }
         // 添加可选任务
         if (optionalSteps.length > 0) {
             content += `\n### 可选任务\n\n`;
             optionalSteps.forEach((step, index) => {
-                content += `- [ ] ${index + 1}. ${step}\n`;
+                content += `- [ ] ${step}\n`;
             });
         }
         return content;

--- a/dist/services/templates/ExecutionTemplateBuilder.js
+++ b/dist/services/templates/ExecutionTemplateBuilder.js
@@ -9,6 +9,8 @@ class ExecutionTemplateBuilder extends TemplateBuilderBase_1.TemplateBuilderBase
     }
     generateProposalTemplate(input) {
         const context = this.inputs.normalizeFeatureTemplateInput(input);
+        this.setReferenceDocumentContext(context.projectRoot, context.documentPath);
+        try {
         const created = this.getCurrentDate();
         const projectDocs = context.projectContext.projectDocs ?? [];
         const moduleSkills = context.projectContext.moduleSkills ?? [];
@@ -156,9 +158,15 @@ ${this.formatChecklist(context.acceptanceCriteria, 'قيد التحديد')}`;
             affects: context.affects,
             flags: context.flags,
         }, this.copy(context.documentLanguage, zh, en, ja, ar));
+        }
+        finally {
+            this.clearReferenceDocumentContext();
+        }
     }
     generateTasksTemplate(input) {
         const context = this.inputs.normalizeFeatureTemplateInput(input);
+        this.setReferenceDocumentContext(context.projectRoot, context.documentPath);
+        try {
         const created = this.getCurrentDate();
         const projectDocs = context.projectContext.projectDocs ?? [];
         const moduleSkills = context.projectContext.moduleSkills ?? [];
@@ -255,9 +263,15 @@ ${optionalStepTasksAr}`.trim();
             created,
             optional_steps: context.optionalSteps,
         }, this.copy(context.documentLanguage, zh, en, ja, ar));
+        }
+        finally {
+            this.clearReferenceDocumentContext();
+        }
     }
     generateVerificationTemplate(input) {
         const context = this.inputs.normalizeFeatureTemplateInput(input);
+        this.setReferenceDocumentContext(context.projectRoot, context.documentPath);
+        try {
         const created = this.getCurrentDate();
         const projectDocs = context.projectContext.projectDocs ?? [];
         const moduleSkills = context.projectContext.moduleSkills ?? [];
@@ -365,9 +379,15 @@ ${this.formatChecklist(context.acceptanceCriteria, 'معيار قبول 1')}
             optional_steps: context.optionalSteps,
             passed_optional_steps: [],
         }, this.copy(context.documentLanguage, zh, en, ja, ar));
+        }
+        finally {
+            this.clearReferenceDocumentContext();
+        }
     }
     generateReviewTemplate(input) {
         const context = this.inputs.normalizeFeatureTemplateInput(input);
+        this.setReferenceDocumentContext(context.projectRoot, context.documentPath);
+        try {
         const created = this.getCurrentDate();
         const projectDocs = context.projectContext.projectDocs ?? [];
         const moduleSkills = context.projectContext.moduleSkills ?? [];
@@ -520,6 +540,10 @@ ${this.formatReferenceList(linkedKnowledgeDocs, 'قيد التحديد')}
             created,
             status: 'pending_review',
         }, this.copy(context.documentLanguage, zh, en, ja, ar));
+        }
+        finally {
+            this.clearReferenceDocumentContext();
+        }
     }
 }
 exports.ExecutionTemplateBuilder = ExecutionTemplateBuilder;

--- a/dist/services/templates/ExecutionTemplateBuilder.js
+++ b/dist/services/templates/ExecutionTemplateBuilder.js
@@ -172,22 +172,22 @@ ${this.formatChecklist(context.acceptanceCriteria, 'قيد التحديد')}`;
         const moduleSkills = context.projectContext.moduleSkills ?? [];
         const optionalStepTasksZh = context.optionalSteps.length > 0
             ? context.optionalSteps
-                .map((step, index) => `- [ ] ${index + 7}. 完成可选步骤 \`${step}\` 的文档和验证`)
+                .map((step) => `- [ ] 完成可选步骤 \`${step}\` 的文档和验证`)
                 .join('\n')
             : '';
         const optionalStepTasksEn = context.optionalSteps.length > 0
             ? context.optionalSteps
-                .map((step, index) => `- [ ] ${index + 7}. Finish docs and verification for optional step \`${step}\``)
+                .map((step) => `- [ ] Finish docs and verification for optional step \`${step}\``)
                 .join('\n')
             : '';
         const optionalStepTasksJa = context.optionalSteps.length > 0
             ? context.optionalSteps
-                .map((step, index) => `- [ ] ${index + 7}. オプション手順 \`${step}\` の文書と検証を完了する`)
+                .map((step) => `- [ ] オプション手順 \`${step}\` の文書と検証を完了する`)
                 .join('\n')
             : '';
         const optionalStepTasksAr = context.optionalSteps.length > 0
             ? context.optionalSteps
-                .map((step, index) => `- [ ] ${index + 7}. أكمل التوثيق والتحقق للخطوة الاختيارية \`${step}\``)
+                .map((step) => `- [ ] أكمل التوثيق والتحقق للخطوة الاختيارية \`${step}\``)
                 .join('\n')
             : '';
         const zh = `## 上下文引用
@@ -200,12 +200,12 @@ ${this.formatReferenceList(moduleSkills, '待补充')}
 
 ## 任务清单
 
-- [ ] 1. 完成实现
-- [ ] 2. 对齐项目规划文档与本次 change 的边界
-- [ ] 3. 更新涉及模块的 \`SKILL.md\`
-- [ ] 4. 更新相关 API / 设计 / 计划文档
-- [ ] 5. 重新生成 \`SKILL.index.json\`
-- [ ] 6. 执行验证并更新 \`verification.md\`
+- [ ] 完成实现
+- [ ] 对齐项目规划文档与本次 change 的边界
+- [ ] 更新涉及模块的 \`SKILL.md\`
+- [ ] 更新相关 API / 设计 / 计划文档
+- [ ] 重新生成 \`SKILL.index.json\`
+- [ ] 执行验证并更新 \`verification.md\`
 ${optionalStepTasksZh}`.trim();
         const en = `## Context References
 
@@ -217,12 +217,12 @@ ${this.formatReferenceList(moduleSkills, 'TBD')}
 
 ## Task Checklist
 
-- [ ] 1. Implement the change
-- [ ] 2. Align project planning docs with this change boundary
-- [ ] 3. Update affected \`SKILL.md\` files
-- [ ] 4. Update related API / design / planning docs
-- [ ] 5. Rebuild \`SKILL.index.json\`
-- [ ] 6. Run verification and update \`verification.md\`
+- [ ] Implement the change
+- [ ] Align project planning docs with this change boundary
+- [ ] Update affected \`SKILL.md\` files
+- [ ] Update related API / design / planning docs
+- [ ] Rebuild \`SKILL.index.json\`
+- [ ] Run verification and update \`verification.md\`
 ${optionalStepTasksEn}`.trim();
         const ja = `## 参照コンテキスト
 
@@ -234,12 +234,12 @@ ${this.formatReferenceList(moduleSkills, '未定')}
 
 ## タスクチェックリスト
 
-- [ ] 1. change を実装する
-- [ ] 2. この change の境界に合わせてプロジェクト計画文書を揃える
-- [ ] 3. 影響を受ける \`SKILL.md\` を更新する
-- [ ] 4. 関連する API / 設計 / 計画文書を更新する
-- [ ] 5. \`SKILL.index.json\` を再生成する
-- [ ] 6. 検証を実行して \`verification.md\` を更新する
+- [ ] change を実装する
+- [ ] この change の境界に合わせてプロジェクト計画文書を揃える
+- [ ] 影響を受ける \`SKILL.md\` を更新する
+- [ ] 関連する API / 設計 / 計画文書を更新する
+- [ ] \`SKILL.index.json\` を再生成する
+- [ ] 検証を実行して \`verification.md\` を更新する
 ${optionalStepTasksJa}`.trim();
         const ar = `## مراجع السياق
 
@@ -251,12 +251,12 @@ ${this.formatReferenceList(moduleSkills, 'قيد التحديد')}
 
 ## قائمة المهام
 
-- [ ] 1. نفّذ التغيير
-- [ ] 2. وحّد وثائق تخطيط المشروع مع حدود هذا change
-- [ ] 3. حدّث ملفات \`SKILL.md\` المتأثرة
-- [ ] 4. حدّث وثائق API / التصميم / التخطيط ذات الصلة
-- [ ] 5. أعد بناء \`SKILL.index.json\`
-- [ ] 6. نفّذ التحقق وحدّث \`verification.md\`
+- [ ] نفّذ التغيير
+- [ ] وحّد وثائق تخطيط المشروع مع حدود هذا change
+- [ ] حدّث ملفات \`SKILL.md\` المتأثرة
+- [ ] حدّث وثائق API / التصميم / التخطيط ذات الصلة
+- [ ] أعد بناء \`SKILL.index.json\`
+- [ ] نفّذ التحقق وحدّث \`verification.md\`
 ${optionalStepTasksAr}`.trim();
         return this.withFrontmatter({
             feature: context.feature,

--- a/dist/services/templates/TemplateBuilderBase.d.ts
+++ b/dist/services/templates/TemplateBuilderBase.d.ts
@@ -1,6 +1,10 @@
 import { FeatureProjectReference, TemplateDocumentLanguage } from './templateTypes';
 type FrontmatterValue = string | number | boolean | string[];
 export declare abstract class TemplateBuilderBase {
+    private referenceProjectRoot?;
+    private referenceDocumentPath?;
+    protected setReferenceDocumentContext(projectRoot: string | undefined, documentPath: string | undefined): void;
+    protected clearReferenceDocumentContext(): void;
     protected getCurrentDate(): string;
     protected isEnglish(language: TemplateDocumentLanguage): boolean;
     protected copy(language: TemplateDocumentLanguage, zh: string, en: string, ja?: string, ar?: string): string;
@@ -13,6 +17,7 @@ export declare abstract class TemplateBuilderBase {
     protected formatReferenceList(items: FeatureProjectReference[], emptyFallback: string): string;
     protected formatReferenceChecklist(items: FeatureProjectReference[], emptyFallback: string): string;
     protected withFrontmatter(fields: Record<string, FrontmatterValue | undefined>, body: string): string;
+    private resolveReferenceHref;
     private toYamlValue;
 }
 export {};

--- a/dist/services/templates/TemplateBuilderBase.js
+++ b/dist/services/templates/TemplateBuilderBase.js
@@ -1,7 +1,19 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.TemplateBuilderBase = void 0;
+const path_1 = __importDefault(require("path"));
 class TemplateBuilderBase {
+    setReferenceDocumentContext(projectRoot, documentPath) {
+        this.referenceProjectRoot = typeof projectRoot === 'string' && projectRoot.trim().length > 0 ? projectRoot : undefined;
+        this.referenceDocumentPath = typeof documentPath === 'string' && documentPath.trim().length > 0 ? documentPath : undefined;
+    }
+    clearReferenceDocumentContext() {
+        this.referenceProjectRoot = undefined;
+        this.referenceDocumentPath = undefined;
+    }
     getCurrentDate() {
         return new Date().toISOString().slice(0, 10);
     }
@@ -40,13 +52,17 @@ class TemplateBuilderBase {
         if (items.length === 0) {
             return `- ${emptyFallback}`;
         }
-        return items.map(item => `- ${item.title}: \`${item.path}\``).join('\n');
+        return items
+            .map(item => `- ${item.title}: [${item.path}](${this.resolveReferenceHref(item.path)})`)
+            .join('\n');
     }
     formatReferenceChecklist(items, emptyFallback) {
         if (items.length === 0) {
             return `- [ ] ${emptyFallback}`;
         }
-        return items.map(item => `- [ ] ${item.path}`).join('\n');
+        return items
+            .map(item => `- [ ] ${item.title}: [${item.path}](${this.resolveReferenceHref(item.path)})`)
+            .join('\n');
     }
     withFrontmatter(fields, body) {
         const frontmatter = Object.entries(fields)
@@ -54,6 +70,19 @@ class TemplateBuilderBase {
             .map(([key, value]) => `${key}: ${this.toYamlValue(value)}`)
             .join('\n');
         return `---\n${frontmatter}\n---\n\n${body.trim()}\n`;
+    }
+    resolveReferenceHref(referencePath) {
+        const normalizedReferencePath = String(referencePath || '').replace(/\\/g, '/');
+        if (!normalizedReferencePath) {
+            return normalizedReferencePath;
+        }
+        if (!this.referenceProjectRoot || !this.referenceDocumentPath) {
+            return normalizedReferencePath;
+        }
+        const targetPath = path_1.default.resolve(this.referenceProjectRoot, normalizedReferencePath);
+        const documentDir = path_1.default.dirname(this.referenceDocumentPath);
+        const relativePath = path_1.default.relative(documentDir, targetPath).replace(/\\/g, '/');
+        return relativePath || '.';
     }
     toYamlValue(value) {
         if (Array.isArray(value)) {

--- a/dist/services/templates/TemplateInputFactory.js
+++ b/dist/services/templates/TemplateInputFactory.js
@@ -20,6 +20,8 @@ class TemplateInputFactory {
                 acceptanceCriteria: [...englishDefaults.acceptanceCriteria],
                 projectContext: this.normalizeFeatureProjectContext(),
                 documentLanguage: 'en-US',
+                projectRoot: undefined,
+                documentPath: undefined,
             };
         }
         const documentLanguage = this.normalizeDocumentLanguage(input.documentLanguage);
@@ -38,6 +40,8 @@ class TemplateInputFactory {
             acceptanceCriteria: input.acceptanceCriteria?.map(item => item.trim()).filter(Boolean) ?? [...localizedDefaults.acceptanceCriteria],
             projectContext: this.normalizeFeatureProjectContext(input.projectContext),
             documentLanguage,
+            projectRoot: typeof input.projectRoot === 'string' && input.projectRoot.trim().length > 0 ? input.projectRoot.trim() : undefined,
+            documentPath: typeof input.documentPath === 'string' && input.documentPath.trim().length > 0 ? input.documentPath.trim() : undefined,
         };
         if (!input.background?.trim()) {
             normalized.background = localizedDefaults.background;

--- a/dist/services/templates/templateTypes.d.ts
+++ b/dist/services/templates/templateTypes.d.ts
@@ -15,6 +15,8 @@ export interface FeatureTemplateInput {
     acceptanceCriteria?: string[];
     projectContext?: FeatureProjectContext;
     documentLanguage?: TemplateDocumentLanguage;
+    projectRoot?: string;
+    documentPath?: string;
 }
 export interface NormalizedFeatureTemplateInput {
     feature: string;
@@ -30,6 +32,8 @@ export interface NormalizedFeatureTemplateInput {
     acceptanceCriteria: string[];
     projectContext: FeatureProjectContext;
     documentLanguage: TemplateDocumentLanguage;
+    projectRoot?: string;
+    documentPath?: string;
 }
 export interface FeatureProjectReference {
     title: string;

--- a/docs/issue-automation.md
+++ b/docs/issue-automation.md
@@ -1,0 +1,188 @@
+# Issue Automation Protocol
+
+## Status
+
+This document defines the repository protocol for a future local-only issue automation tool.
+
+Current status:
+
+- OSpec does not ship a built-in `issue` command
+- this repository does not include the automation program itself
+- the automation program is expected to run locally, outside this repository
+- this document is the contract that the local automation must follow
+
+## Goals
+
+The local automation should be able to:
+
+1. fetch or inspect the current GitHub issue list
+2. select one issue to work on
+3. create a dedicated git branch for that issue
+4. implement the fix in the repository
+5. add or update regression tests under `tests/`
+6. run verification before handoff
+7. produce a concise implementation and validation summary
+
+## Non-Goals
+
+This protocol does not require the automation to:
+
+- close GitHub issues automatically before review
+- bypass human review
+- auto-merge pull requests
+- rewrite unrelated tests or docs
+- force `ospec update` or archive old changes automatically
+
+## Local-Only Rule
+
+The automation program itself should stay outside this repository until the workflow is stable.
+
+Repository-managed content:
+
+- this protocol document
+- regression tests added for specific fixes
+- source changes required to resolve the issue
+
+Local-only content:
+
+- GitHub tokens
+- personal scripts, wrappers, or launchers
+- machine-specific paths
+- local prompt packs or agent orchestration files
+
+## Required Preconditions
+
+Before the automation starts work on an issue, it must confirm:
+
+- the repository is clean, or the user explicitly accepts the current dirty state
+- the base branch is known, normally `main`
+- GitHub issue access is available
+- local test tooling is available
+- the issue is still open
+
+If any of those checks fail, the automation should stop and report the blocker.
+
+## Issue Intake
+
+For each issue, the automation should capture at least:
+
+- issue number
+- issue title
+- issue URL
+- current issue body
+- current repository HEAD and base branch
+
+It should then restate the issue in repository terms:
+
+- affected files or subsystems
+- expected behavior
+- current behavior
+- likely verification scope
+
+## Branch Policy
+
+Each issue should use a dedicated branch.
+
+Recommended branch format:
+
+```text
+issue/<number>-<short-slug>
+```
+
+Examples:
+
+```text
+issue/5-tasks-md-checklist-format
+issue/6-tasks-md-validation-frontmatter
+```
+
+The automation should:
+
+1. fetch the latest base branch
+2. create the issue branch from the latest base branch
+3. keep all issue-specific work on that branch
+
+## Fix Workflow
+
+The automation should follow this order:
+
+1. inspect the issue and reproduce the behavior
+2. identify the smallest correct fix
+3. implement the code change
+4. add or update regression coverage under `tests/`
+5. run targeted verification
+6. run broader verification when the change touches shared workflow paths
+7. summarize changed files, test results, and residual risks
+
+## Testing Policy
+
+Every issue fix should leave behind regression coverage when practical.
+
+Expected rules:
+
+- prefer focused tests in `tests/`
+- keep regression tests close to the fixed behavior
+- do not rely only on one-off manual validation
+- if the fix affects shared workflow behavior, also run a broader smoke check
+
+Examples of broader verification:
+
+```bash
+npx vitest run tests/<targeted-test>.mjs
+node scripts/release-smoke.js
+```
+
+If broader verification is skipped, the automation should explain why.
+
+## Validation Output
+
+Before handoff, the automation should produce:
+
+- issue number and title
+- branch name
+- changed files
+- added or updated tests
+- commands that were run
+- pass/fail result for each command
+- remaining risks or assumptions
+
+## Closeout Policy
+
+The automation should not close the GitHub issue only because code was written locally.
+
+Recommended closeout order:
+
+1. fix the issue on the issue branch
+2. run regression checks
+3. hand off for review or open a PR
+4. close the issue only after the fix is accepted
+
+## Recommended Local Tool Shape
+
+The local automation program can be implemented later using any local stack, but it should expose a flow equivalent to:
+
+1. list issues
+2. pick issue
+3. create branch
+4. run fix workflow
+5. run validation
+6. print handoff summary
+
+Possible local integrations:
+
+- GitHub CLI
+- GitHub REST API
+- Codex or Claude orchestration
+- local PowerShell or Node.js wrappers
+
+## Minimum Acceptance For Future Implementation
+
+A future implementation should not be considered complete until it can demonstrate all of the following:
+
+- reads the live open issue list
+- creates an issue branch correctly
+- preserves unrelated local work
+- updates repository files without destructive git actions
+- adds or updates regression coverage in `tests/`
+- runs validation commands and reports the results
+- leaves the repository ready for human review

--- a/scripts/release-smoke.js
+++ b/scripts/release-smoke.js
@@ -112,6 +112,18 @@ function assertContains(output, expected, label) {
 
 
 
+function assertNotContains(output, unexpected, label) {
+
+  if (output.includes(unexpected)) {
+
+    throw new Error(`Expected ${label} to exclude "${unexpected}"\nActual output:\n${output}`);
+
+  }
+
+}
+
+
+
 function toPosixRelative(from, to) {
 
   return path.relative(from, to).replace(/\\/g, '/');
@@ -412,7 +424,13 @@ async function main() {
 
     assertContains(await fs.readFile(proposalPath, 'utf8'), activeOverviewLink, 'proposal link');
 
-    assertContains(await fs.readFile(tasksPath, 'utf8'), activeOverviewLink, 'tasks link');
+    const tasksContent = await fs.readFile(tasksPath, 'utf8');
+
+    assertContains(tasksContent, activeOverviewLink, 'tasks link');
+
+    assertContains(tasksContent, '- [ ] Implement the change', 'tasks checklist format');
+
+    assertNotContains(tasksContent, '- [ ] 1.', 'tasks hybrid checklist numbering');
 
     assertContains(await fs.readFile(verificationPath, 'utf8'), activeOverviewLink, 'verification link');
 

--- a/scripts/release-smoke.js
+++ b/scripts/release-smoke.js
@@ -112,6 +112,72 @@ function assertContains(output, expected, label) {
 
 
 
+function toPosixRelative(from, to) {
+
+  return path.relative(from, to).replace(/\\/g, '/');
+
+}
+
+
+
+async function findArchivedChangeDir(archivedRoot, changeName) {
+
+  if (!(await fs.pathExists(archivedRoot))) {
+
+    return null;
+
+  }
+
+
+
+  const entries = await fs.readdir(archivedRoot, { withFileTypes: true });
+
+  for (const entry of entries) {
+
+    if (!entry.isDirectory()) {
+
+      continue;
+
+    }
+
+
+
+    const entryPath = path.join(archivedRoot, entry.name);
+
+    const statePath = path.join(entryPath, 'state.json');
+
+    if (await fs.pathExists(statePath)) {
+
+      const state = await fs.readJson(statePath);
+
+      if (state.feature === changeName && state.status === 'archived') {
+
+        return entryPath;
+
+      }
+
+    }
+
+
+
+    const nestedMatch = await findArchivedChangeDir(entryPath, changeName);
+
+    if (nestedMatch) {
+
+      return nestedMatch;
+
+    }
+
+  }
+
+
+
+  return null;
+
+}
+
+
+
 async function main() {
 
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ospec-release-smoke-'));
@@ -332,9 +398,25 @@ async function main() {
 
     const statePath = path.join(featureDir, 'state.json');
 
+    const proposalPath = path.join(featureDir, 'proposal.md');
+
     const tasksPath = path.join(featureDir, 'tasks.md');
 
     const verificationPath = path.join(featureDir, 'verification.md');
+
+    const reviewPath = path.join(featureDir, 'review.md');
+
+    const projectOverviewPath = path.join(projectDir, 'docs', 'project', 'overview.md');
+
+    const activeOverviewLink = `[docs/project/overview.md](${toPosixRelative(featureDir, projectOverviewPath)})`;
+
+    assertContains(await fs.readFile(proposalPath, 'utf8'), activeOverviewLink, 'proposal link');
+
+    assertContains(await fs.readFile(tasksPath, 'utf8'), activeOverviewLink, 'tasks link');
+
+    assertContains(await fs.readFile(verificationPath, 'utf8'), activeOverviewLink, 'verification link');
+
+    assertContains(await fs.readFile(reviewPath, 'utf8'), activeOverviewLink, 'review link');
 
     const state = await fs.readJson(statePath);
 
@@ -357,31 +439,45 @@ async function main() {
 
     await fs.writeJson(statePath, state, { spaces: 2 });
 
-    await fs.writeFile(
+    await fs.writeFile(tasksPath, (await fs.readFile(tasksPath, 'utf8')).replace(/- \[ \]/g, '- [x]'), 'utf8');
 
-      tasksPath,
-
-      ['---', 'feature: release-smoke', 'created: 2026-03-25', 'optional_steps: []', '---', '', '## Tasks', '', '- [x] Done', ''].join('\n'),
-
-      'utf8'
-
-    );
-
-    await fs.writeFile(
-
-      verificationPath,
-
-      ['---', 'feature: release-smoke', 'created: 2026-03-25', 'status: verifying', 'optional_steps: []', 'passed_optional_steps: []', '---', '', '## Verification', '', '- [x] build passed', '- [x] test passed', ''].join('\n'),
-
-      'utf8'
-
-    );
+    await fs.writeFile(verificationPath, (await fs.readFile(verificationPath, 'utf8')).replace(/- \[ \]/g, '- [x]'), 'utf8');
 
 
 
     output = run('node', [cliPath, 'finalize', featureDir]);
 
     assertContains(output, 'Change finalized:', 'finalize output');
+
+    const archivedFeatureDir = await findArchivedChangeDir(path.join(projectDir, 'changes', 'archived'), 'release-smoke');
+
+    if (!archivedFeatureDir) {
+
+      throw new Error('Expected release-smoke to be archived');
+
+    }
+
+
+
+    const archivedOverviewLink = `[docs/project/overview.md](${toPosixRelative(archivedFeatureDir, projectOverviewPath)})`;
+
+    assertContains(await fs.readFile(path.join(archivedFeatureDir, 'proposal.md'), 'utf8'), archivedOverviewLink, 'archived proposal link');
+
+    assertContains(await fs.readFile(path.join(archivedFeatureDir, 'tasks.md'), 'utf8'), archivedOverviewLink, 'archived tasks link');
+
+    assertContains(await fs.readFile(path.join(archivedFeatureDir, 'verification.md'), 'utf8'), archivedOverviewLink, 'archived verification link');
+
+    assertContains(await fs.readFile(path.join(archivedFeatureDir, 'review.md'), 'utf8'), archivedOverviewLink, 'archived review link');
+
+    output = run('node', [cliPath, 'queue', 'next', projectDir]);
+
+    assertContains(output, 'Activated next queued change: queued-smoke', 'queue next output');
+
+    const activatedQueuedDir = path.join(projectDir, 'changes', 'active', 'queued-smoke');
+
+    const queuedOverviewLink = `[docs/project/overview.md](${toPosixRelative(activatedQueuedDir, projectOverviewPath)})`;
+
+    assertContains(await fs.readFile(path.join(activatedQueuedDir, 'tasks.md'), 'utf8'), queuedOverviewLink, 'activated queued change link');
 
 
 

--- a/tests/change-markdown-links.test.mjs
+++ b/tests/change-markdown-links.test.mjs
@@ -1,0 +1,86 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { services } from '../dist/services/index.js';
+
+const tempDirs = [];
+
+function trackTempDir(dirPath) {
+  tempDirs.push(dirPath);
+  return dirPath;
+}
+
+function toPosix(value) {
+  return value.replace(/\\/g, '/');
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dirPath = tempDirs.pop();
+    await fs.remove(dirPath);
+  }
+});
+
+describe('change markdown links', () => {
+  it('generates repo-doc links relative to the change document', () => {
+    const projectRoot = path.resolve('C:/repo');
+    const documentPath = path.join(projectRoot, 'changes', 'active', 'demo-change', 'tasks.md');
+    const overviewPath = 'docs/project/overview.md';
+    const expectedHref = '../../../docs/project/overview.md';
+
+    const output = services.templateEngine.generateTasksTemplate({
+      feature: 'demo-change',
+      documentLanguage: 'en-US',
+      projectRoot,
+      documentPath,
+      projectContext: {
+        projectDocs: [
+          {
+            title: 'Project overview',
+            path: overviewPath,
+          },
+        ],
+      },
+    });
+
+    expect(output).toContain(`[${overviewPath}](${expectedHref})`);
+  });
+
+  it('rebases moved change markdown links without touching internal links', async () => {
+    const tempRoot = trackTempDir(await fs.mkdtemp(path.join(os.tmpdir(), 'ospec-link-unit-')));
+    const previousChangePath = path.join(tempRoot, 'changes', 'active', 'demo-change');
+    const nextChangePath = path.join(tempRoot, 'changes', 'archived', '2026-04', '2026-04-04', 'demo-change');
+
+    await fs.ensureDir(previousChangePath);
+    await fs.ensureDir(nextChangePath);
+
+    const previousTasksPath = path.join(previousChangePath, 'tasks.md');
+    const nextTasksPath = path.join(nextChangePath, 'tasks.md');
+    const externalTargetPath = path.join(tempRoot, 'docs', 'project', 'overview.md');
+
+    await fs.ensureDir(path.dirname(externalTargetPath));
+    await fs.writeFile(externalTargetPath, '# overview\n', 'utf8');
+
+    const originalTasks = [
+      '# Tasks',
+      '',
+      '- External: [docs/project/overview.md](../../../docs/project/overview.md)',
+      '- Internal: [verification.md](verification.md)',
+      '',
+    ].join('\n');
+
+    await fs.writeFile(previousTasksPath, originalTasks, 'utf8');
+    await fs.writeFile(nextTasksPath, originalTasks, 'utf8');
+    await fs.writeFile(path.join(nextChangePath, 'verification.md'), '# Verification\n', 'utf8');
+
+    await services.projectService.rebaseMovedChangeMarkdownLinks(previousChangePath, nextChangePath);
+
+    const updatedTasks = await fs.readFile(nextTasksPath, 'utf8');
+    const expectedExternalHref = toPosix(path.relative(nextChangePath, externalTargetPath));
+
+    expect(updatedTasks).toContain(`[docs/project/overview.md](${expectedExternalHref})`);
+    expect(updatedTasks).toContain('[verification.md](verification.md)');
+  });
+});

--- a/tests/tasks-template-format.test.mjs
+++ b/tests/tasks-template-format.test.mjs
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { TemplateGenerator } from '../dist/services/TemplateGenerator.js';
+import { services } from '../dist/services/index.js';
+
+const languages = ['zh-CN', 'en-US', 'ja-JP', 'ar'];
+
+describe('tasks template checklist format', () => {
+  for (const language of languages) {
+    it(`uses a pure checklist structure for ${language}`, () => {
+      const output = services.templateEngine.generateTasksTemplate({
+        feature: 'demo-change',
+        documentLanguage: language,
+        projectRoot: 'C:/repo',
+        documentPath: 'C:/repo/changes/active/demo-change/tasks.md',
+        projectContext: {},
+        optionalSteps: ['demo-step'],
+      });
+
+      expect(output).not.toMatch(/- \[ \] \d+\./);
+      expect(output).toMatch(/- \[ \] /);
+    });
+  }
+
+  it('keeps the legacy template generator aligned with pure checklist items', () => {
+    const output = TemplateGenerator.generateTasksTemplate(
+      'demo-change',
+      ['Implement feature', 'Update docs'],
+      ['Optional verification'],
+    );
+
+    expect(output).not.toMatch(/- \[ \] \d+\./);
+    expect(output).toContain('- [ ] Implement feature');
+    expect(output).toContain('- [ ] Update docs');
+    expect(output).toContain('- [ ] Optional verification');
+  });
+});


### PR DESCRIPTION
﻿## Summary

- replace hybrid checklist numbering in generated `tasks.md`
- align the legacy template generator with the same pure checklist format
- add targeted regression coverage and strengthen the smoke assertion

## Validation

- `npx vitest run tests/tasks-template-format.test.mjs tests/change-markdown-links.test.mjs`
- `node .\scripts\release-smoke.js`
- `node` direct template probe for generated tasks output
- `git diff --check`

Fixes #5
