### PR TITLE
Fix tasks and verification validation for malformed markdown

### DIFF
--- a/dist/commands/VerifyCommand.js
+++ b/dist/commands/VerifyCommand.js
@@ -98,48 +98,12 @@ class VerifyCommand extends BaseCommand_1.BaseCommand {
                 });
             }
             if (tasksExists) {
-                const tasksContent = await services_1.services.fileService.readFile(tasksPath);
-                const tasks = (0, gray_matter_1.default)(tasksContent);
-                const optionalSteps = Array.isArray(tasks.data.optional_steps)
-                    ? tasks.data.optional_steps
-                    : [];
-                const missing = activatedSteps.filter(step => !optionalSteps.includes(step));
-                checks.push({
-                    name: 'tasks.optional_steps',
-                    status: missing.length === 0 ? 'pass' : 'fail',
-                    message: missing.length === 0
-                        ? 'All activated optional steps are present in tasks.md'
-                        : `Missing optional steps in tasks.md: ${missing.join(', ')}`,
-                });
-                checks.push({
-                    name: 'tasks checklist',
-                    status: /- \[ \]/.test(tasksContent) ? 'warn' : 'pass',
-                    message: /- \[ \]/.test(tasksContent)
-                        ? 'tasks.md still has unchecked items'
-                        : 'tasks.md checklist is complete',
-                });
+                const tasksAnalysis = await services_1.services.projectService.analyzeChecklistDocument(tasksPath, 'tasks.md', activatedSteps);
+                checks.push(...tasksAnalysis.checks);
             }
             if (verificationExists) {
-                const verificationContent = await services_1.services.fileService.readFile(verificationPath);
-                const verification = (0, gray_matter_1.default)(verificationContent);
-                const optionalSteps = Array.isArray(verification.data.optional_steps)
-                    ? verification.data.optional_steps
-                    : [];
-                const missing = activatedSteps.filter(step => !optionalSteps.includes(step));
-                checks.push({
-                    name: 'verification.optional_steps',
-                    status: missing.length === 0 ? 'pass' : 'fail',
-                    message: missing.length === 0
-                        ? 'All activated optional steps are present in verification.md'
-                        : `Missing optional steps in verification.md: ${missing.join(', ')}`,
-                });
-                checks.push({
-                    name: 'verification checklist',
-                    status: /- \[ \]/.test(verificationContent) ? 'warn' : 'pass',
-                    message: /- \[ \]/.test(verificationContent)
-                        ? 'verification.md still has unchecked items'
-                        : 'verification.md checklist is complete',
-                });
+                const verificationAnalysis = await services_1.services.projectService.analyzeVerificationDocument(verificationPath, activatedSteps);
+                checks.push(...verificationAnalysis.checks);
             }
             if (activatedSteps.includes('stitch_design_review')) {
                 const approvalPath = path.join(targetPath, 'artifacts', 'stitch', 'approval.json');

--- a/dist/services/ProjectService.js
+++ b/dist/services/ProjectService.js
@@ -11080,197 +11080,103 @@ ${formatSuggestion()}
 
 
         const content = await this.fileService.readFile(filePath);
-
-
-
-
-
-
-
-        const parsed = (0, gray_matter_1.default)(content);
-
-
-
-
-
-
-
-        const optionalSteps = Array.isArray(parsed.data.optional_steps) ? parsed.data.optional_steps : [];
-
-
-
-
-
-
-
-        const missing = activatedSteps.filter(step => !optionalSteps.includes(step));
-
-
-
-
-
-
-
-        const checklistComplete = !/- \[ \]/.test(content);
-
-
-
-
-
-
-
+        const hasFrontmatter = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.test(content);
+        let parsed = null;
+        let parseError = null;
+        if (hasFrontmatter) {
+            try {
+                parsed = (0, gray_matter_1.default)(content);
+            }
+            catch (error) {
+                parseError = error;
+            }
+        }
+        const data = parsed?.data ?? {};
+        const optionalStepsFieldValid = Array.isArray(data.optional_steps);
+        const optionalSteps = optionalStepsFieldValid ? data.optional_steps : [];
+        const createdFieldValid = (typeof data.created === 'string' && data.created.trim().length > 0) ||
+            (data.created instanceof Date && !Number.isNaN(data.created.getTime()));
+        const missingRequiredFields = [];
+        if (typeof data.feature !== 'string' || data.feature.trim().length === 0) {
+            missingRequiredFields.push('feature');
+        }
+        if (!createdFieldValid) {
+            missingRequiredFields.push('created');
+        }
+        if (!optionalStepsFieldValid) {
+            missingRequiredFields.push('optional_steps');
+        }
+        const missing = optionalStepsFieldValid
+            ? activatedSteps.filter(step => !optionalSteps.includes(step))
+            : [...activatedSteps];
+        const checklistItems = parsed?.content.match(/^\s*-\s+\[(?: |x|X)\]\s+.+$/gm) ?? [];
+        const uncheckedItems = parsed?.content.match(/^\s*-\s+\[ \]\s+.+$/gm) ?? [];
+        const checklistStructureValid = checklistItems.length > 0;
+        const checklistComplete = hasFrontmatter &&
+            parseError === null &&
+            missingRequiredFields.length === 0 &&
+            checklistStructureValid &&
+            uncheckedItems.length === 0;
+        let frontmatterMessage = `${name} frontmatter parsed successfully`;
+        if (!hasFrontmatter) {
+            frontmatterMessage = `${name} is missing a valid frontmatter block`;
+        }
+        else if (parseError) {
+            frontmatterMessage = `${name} frontmatter cannot be parsed: ${parseError.message}`;
+        }
+        let requiredFieldsMessage = `${name} has all required frontmatter fields`;
+        if (!hasFrontmatter || parseError) {
+            requiredFieldsMessage = `Cannot validate required fields in ${name} because frontmatter is invalid`;
+        }
+        else if (missingRequiredFields.length > 0) {
+            requiredFieldsMessage = `Missing or invalid required fields in ${name}: ${missingRequiredFields.join(', ')}`;
+        }
+        let optionalStepsMessage = `All activated optional steps are present in ${name}`;
+        if (!optionalStepsFieldValid) {
+            optionalStepsMessage = `${name} frontmatter field optional_steps must be an array`;
+        }
+        else if (missing.length > 0) {
+            optionalStepsMessage = `Missing optional steps in ${name}: ${missing.join(', ')}`;
+        }
+        let checklistStatus = 'pass';
+        let checklistMessage = `${name} checklist is complete`;
+        if (!hasFrontmatter || parseError) {
+            checklistStatus = 'fail';
+            checklistMessage = `${name} checklist cannot be validated because frontmatter is invalid`;
+        }
+        else if (!checklistStructureValid) {
+            checklistStatus = 'fail';
+            checklistMessage = `${name} must contain at least one Markdown checklist item`;
+        }
+        else if (uncheckedItems.length > 0) {
+            checklistStatus = 'warn';
+            checklistMessage = `${name} still has unchecked items`;
+        }
         return {
-
-
-
-
-
-
-
             optionalSteps,
-
-
-
-
-
-
-
             checklistComplete,
-
-
-
-
-
-
-
             checks: [
-
-
-
-
-
-
-
                 {
-
-
-
-
-
-
-
+                    name: `${name}.frontmatter`,
+                    status: hasFrontmatter && parseError === null ? 'pass' : 'fail',
+                    message: frontmatterMessage,
+                },
+                {
+                    name: `${name}.required_fields`,
+                    status: hasFrontmatter && parseError === null && missingRequiredFields.length === 0 ? 'pass' : 'fail',
+                    message: requiredFieldsMessage,
+                },
+                {
                     name: `${name}.optional_steps`,
-
-
-
-
-
-
-
-                    status: missing.length === 0 ? 'pass' : 'fail',
-
-
-
-
-
-
-
-                    message: missing.length === 0
-
-
-
-
-
-
-
-                        ? `All activated optional steps are present in ${name}`
-
-
-
-
-
-
-
-                        : `Missing optional steps in ${name}: ${missing.join(', ')}`,
-
-
-
-
-
-
-
+                    status: optionalStepsFieldValid && missing.length === 0 ? 'pass' : 'fail',
+                    message: optionalStepsMessage,
                 },
-
-
-
-
-
-
-
                 {
-
-
-
-
-
-
-
                     name: `${name}.checklist`,
-
-
-
-
-
-
-
-                    status: checklistComplete ? 'pass' : 'warn',
-
-
-
-
-
-
-
-                    message: checklistComplete
-
-
-
-
-
-
-
-                        ? `${name} checklist is complete`
-
-
-
-
-
-
-
-                        : `${name} still has unchecked items`,
-
-
-
-
-
-
-
+                    status: checklistStatus,
+                    message: checklistMessage,
                 },
-
-
-
-
-
-
-
             ],
-
-
-
-
-
-
-
         };
 
 
@@ -11296,229 +11202,112 @@ ${formatSuggestion()}
 
 
         const content = await this.fileService.readFile(filePath);
-
-
-
-
-
-
-
-        const parsed = (0, gray_matter_1.default)(content);
-
-
-
-
-
-
-
-        const optionalSteps = Array.isArray(parsed.data.optional_steps) ? parsed.data.optional_steps : [];
-
-
-
-
-
-
-
-        const passedOptionalSteps = Array.isArray(parsed.data.passed_optional_steps)
-
-
-
-
-
-
-
-            ? parsed.data.passed_optional_steps
-
-
-
-
-
-
-
-            : [];
-
-
-
-
-
-
-
-        const missing = activatedSteps.filter(step => !optionalSteps.includes(step));
-
-
-
-
-
-
-
-        const checklistComplete = !/- \[ \]/.test(content);
-
-
-
-
-
-
-
+        const hasFrontmatter = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.test(content);
+        let parsed = null;
+        let parseError = null;
+        if (hasFrontmatter) {
+            try {
+                parsed = (0, gray_matter_1.default)(content);
+            }
+            catch (error) {
+                parseError = error;
+            }
+        }
+        const data = parsed?.data ?? {};
+        const optionalStepsFieldValid = Array.isArray(data.optional_steps);
+        const passedOptionalStepsFieldValid = Array.isArray(data.passed_optional_steps);
+        const optionalSteps = optionalStepsFieldValid ? data.optional_steps : [];
+        const passedOptionalSteps = passedOptionalStepsFieldValid ? data.passed_optional_steps : [];
+        const createdFieldValid = (typeof data.created === 'string' && data.created.trim().length > 0) ||
+            (data.created instanceof Date && !Number.isNaN(data.created.getTime()));
+        const missingRequiredFields = [];
+        if (typeof data.feature !== 'string' || data.feature.trim().length === 0) {
+            missingRequiredFields.push('feature');
+        }
+        if (!createdFieldValid) {
+            missingRequiredFields.push('created');
+        }
+        if (typeof data.status !== 'string' || data.status.trim().length === 0) {
+            missingRequiredFields.push('status');
+        }
+        if (!optionalStepsFieldValid) {
+            missingRequiredFields.push('optional_steps');
+        }
+        if (!passedOptionalStepsFieldValid) {
+            missingRequiredFields.push('passed_optional_steps');
+        }
+        const missing = optionalStepsFieldValid
+            ? activatedSteps.filter(step => !optionalSteps.includes(step))
+            : [...activatedSteps];
+        const checklistItems = parsed?.content.match(/^\s*-\s+\[(?: |x|X)\]\s+.+$/gm) ?? [];
+        const uncheckedItems = parsed?.content.match(/^\s*-\s+\[ \]\s+.+$/gm) ?? [];
+        const checklistStructureValid = checklistItems.length > 0;
+        const checklistComplete = hasFrontmatter &&
+            parseError === null &&
+            missingRequiredFields.length === 0 &&
+            checklistStructureValid &&
+            uncheckedItems.length === 0;
+        let frontmatterMessage = 'verification.md frontmatter parsed successfully';
+        if (!hasFrontmatter) {
+            frontmatterMessage = 'verification.md is missing a valid frontmatter block';
+        }
+        else if (parseError) {
+            frontmatterMessage = `verification.md frontmatter cannot be parsed: ${parseError.message}`;
+        }
+        let requiredFieldsMessage = 'verification.md has all required frontmatter fields';
+        if (!hasFrontmatter || parseError) {
+            requiredFieldsMessage = 'Cannot validate required fields in verification.md because frontmatter is invalid';
+        }
+        else if (missingRequiredFields.length > 0) {
+            requiredFieldsMessage = `Missing or invalid required fields in verification.md: ${missingRequiredFields.join(', ')}`;
+        }
+        let optionalStepsMessage = 'All activated optional steps are present in verification.md';
+        if (!optionalStepsFieldValid) {
+            optionalStepsMessage = 'verification.md frontmatter field optional_steps must be an array';
+        }
+        else if (missing.length > 0) {
+            optionalStepsMessage = `Missing optional steps in verification.md: ${missing.join(', ')}`;
+        }
+        let checklistStatus = 'pass';
+        let checklistMessage = 'verification.md checklist is complete';
+        if (!hasFrontmatter || parseError) {
+            checklistStatus = 'fail';
+            checklistMessage = 'verification.md checklist cannot be validated because frontmatter is invalid';
+        }
+        else if (!checklistStructureValid) {
+            checklistStatus = 'fail';
+            checklistMessage = 'verification.md must contain at least one Markdown checklist item';
+        }
+        else if (uncheckedItems.length > 0) {
+            checklistStatus = 'warn';
+            checklistMessage = 'verification.md still has unchecked items';
+        }
         return {
-
-
-
-
-
-
-
             optionalSteps,
-
-
-
-
-
-
-
             passedOptionalSteps,
-
-
-
-
-
-
-
             checklistComplete,
-
-
-
-
-
-
-
             checks: [
-
-
-
-
-
-
-
                 {
-
-
-
-
-
-
-
+                    name: 'verification.md.frontmatter',
+                    status: hasFrontmatter && parseError === null ? 'pass' : 'fail',
+                    message: frontmatterMessage,
+                },
+                {
+                    name: 'verification.md.required_fields',
+                    status: hasFrontmatter && parseError === null && missingRequiredFields.length === 0 ? 'pass' : 'fail',
+                    message: requiredFieldsMessage,
+                },
+                {
                     name: 'verification.md.optional_steps',
-
-
-
-
-
-
-
-                    status: missing.length === 0 ? 'pass' : 'fail',
-
-
-
-
-
-
-
-                    message: missing.length === 0
-
-
-
-
-
-
-
-                        ? 'All activated optional steps are present in verification.md'
-
-
-
-
-
-
-
-                        : `Missing optional steps in verification.md: ${missing.join(', ')}`,
-
-
-
-
-
-
-
+                    status: optionalStepsFieldValid && missing.length === 0 ? 'pass' : 'fail',
+                    message: optionalStepsMessage,
                 },
-
-
-
-
-
-
-
                 {
-
-
-
-
-
-
-
                     name: 'verification.md.checklist',
-
-
-
-
-
-
-
-                    status: checklistComplete ? 'pass' : 'warn',
-
-
-
-
-
-
-
-                    message: checklistComplete
-
-
-
-
-
-
-
-                        ? 'verification.md checklist is complete'
-
-
-
-
-
-
-
-                        : 'verification.md still has unchecked items',
-
-
-
-
-
-
-
+                    status: checklistStatus,
+                    message: checklistMessage,
                 },
-
-
-
-
-
-
-
             ],
-
-
-
-
-
-
-
         };
 
 

--- a/dist/tools/build-index.js
+++ b/dist/tools/build-index.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const fsp = require('fs/promises');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const matter = require('gray-matter');
 
 const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', 'changes', 'for-ai']);
 const INDEX_FILE = 'SKILL.index.json';
@@ -282,46 +283,31 @@ async function buildChangeSummary(rootDir, changeName, config) {
   }
 
   if (tasksExists) {
-    const tasks = parseFrontmatter(await fsp.readFile(tasksPath, 'utf8'));
-    const optionalSteps = ensureArray(tasks.data.optional_steps);
-    const missing = activatedSteps.filter(step => !optionalSteps.includes(step));
-    const checklistComplete = !/- \[ \]/.test(tasks.body);
-    checks.push({
-      name: 'tasks.md.optional_steps',
-      status: missing.length === 0 ? 'pass' : 'fail',
-      message:
-        missing.length === 0
-          ? 'All activated optional steps are present in tasks.md'
-          : `Missing optional steps in tasks.md: ${missing.join(', ')}`,
+    const tasks = analyzeWorkflowChecklistDocument(await fsp.readFile(tasksPath, 'utf8'), {
+      name: 'tasks.md',
+      activatedSteps,
+      requiredFields: [
+        ['feature', 'string'],
+        ['created', 'string_or_date'],
+        ['optional_steps', 'array'],
+      ],
     });
-    checks.push({
-      name: 'tasks.md.checklist',
-      status: checklistComplete ? 'pass' : 'warn',
-      message: checklistComplete ? 'tasks.md checklist is complete' : 'tasks.md still has unchecked items',
-    });
+    checks.push(...tasks.checks);
   }
 
   if (verificationExists) {
-    const verification = parseFrontmatter(await fsp.readFile(verificationPath, 'utf8'));
-    const optionalSteps = ensureArray(verification.data.optional_steps);
-    const missing = activatedSteps.filter(step => !optionalSteps.includes(step));
-    const checklistComplete = !/- \[ \]/.test(verification.body);
-    checks.push({
-      name: 'verification.md.optional_steps',
-      status: missing.length === 0 ? 'pass' : 'fail',
-      message:
-        missing.length === 0
-          ? 'All activated optional steps are present in verification.md'
-          : `Missing optional steps in verification.md: ${missing.join(', ')}`,
+    const verification = analyzeWorkflowChecklistDocument(await fsp.readFile(verificationPath, 'utf8'), {
+      name: 'verification.md',
+      activatedSteps,
+      requiredFields: [
+        ['feature', 'string'],
+        ['created', 'string_or_date'],
+        ['status', 'string'],
+        ['optional_steps', 'array'],
+        ['passed_optional_steps', 'array'],
+      ],
     });
-    checks.push({
-      name: 'verification.md.checklist',
-      status: checklistComplete ? 'pass' : 'warn',
-      message:
-        checklistComplete
-          ? 'verification.md checklist is complete'
-          : 'verification.md still has unchecked items',
-    });
+    checks.push(...verification.checks);
   }
 
   const hasProtocolIssues = checks.some(check => check.status !== 'pass');
@@ -476,6 +462,93 @@ function parseSkillFile(content) {
   };
 }
 
+function analyzeWorkflowChecklistDocument(content, options) {
+  const hasFrontmatter = /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.test(content);
+  let parsed = null;
+  let parseError = null;
+
+  if (hasFrontmatter) {
+    try {
+      parsed = matter(content);
+    } catch (error) {
+      parseError = error;
+    }
+  }
+
+  const data = parsed?.data ?? {};
+  const optionalStepsFieldValid = Array.isArray(data.optional_steps);
+  const optionalSteps = optionalStepsFieldValid ? ensureArray(data.optional_steps) : [];
+  const invalidRequiredFields = options.requiredFields
+    .filter(([fieldName, fieldType]) => !isValidFrontmatterField(data[fieldName], fieldType))
+    .map(([fieldName]) => fieldName);
+  const missingActivatedSteps = optionalStepsFieldValid
+    ? options.activatedSteps.filter(step => !optionalSteps.includes(step))
+    : [...options.activatedSteps];
+  const checklistItems = parsed?.content.match(/^\s*-\s+\[(?: |x|X)\]\s+.+$/gm) ?? [];
+  const uncheckedItems = parsed?.content.match(/^\s*-\s+\[ \]\s+.+$/gm) ?? [];
+  const checklistStructureValid = checklistItems.length > 0;
+
+  let frontmatterMessage = `${options.name} frontmatter parsed successfully`;
+  if (!hasFrontmatter) {
+    frontmatterMessage = `${options.name} is missing a valid frontmatter block`;
+  } else if (parseError) {
+    frontmatterMessage = `${options.name} frontmatter cannot be parsed: ${parseError.message}`;
+  }
+
+  let requiredFieldsMessage = `${options.name} has all required frontmatter fields`;
+  if (!hasFrontmatter || parseError) {
+    requiredFieldsMessage = `Cannot validate required fields in ${options.name} because frontmatter is invalid`;
+  } else if (invalidRequiredFields.length > 0) {
+    requiredFieldsMessage = `Missing or invalid required fields in ${options.name}: ${invalidRequiredFields.join(', ')}`;
+  }
+
+  let optionalStepsMessage = `All activated optional steps are present in ${options.name}`;
+  if (!optionalStepsFieldValid) {
+    optionalStepsMessage = `${options.name} frontmatter field optional_steps must be an array`;
+  } else if (missingActivatedSteps.length > 0) {
+    optionalStepsMessage = `Missing optional steps in ${options.name}: ${missingActivatedSteps.join(', ')}`;
+  }
+
+  let checklistStatus = 'pass';
+  let checklistMessage = `${options.name} checklist is complete`;
+  if (!hasFrontmatter || parseError) {
+    checklistStatus = 'fail';
+    checklistMessage = `${options.name} checklist cannot be validated because frontmatter is invalid`;
+  } else if (!checklistStructureValid) {
+    checklistStatus = 'fail';
+    checklistMessage = `${options.name} must contain at least one Markdown checklist item`;
+  } else if (uncheckedItems.length > 0) {
+    checklistStatus = 'warn';
+    checklistMessage = `${options.name} still has unchecked items`;
+  }
+
+  return {
+    optionalSteps,
+    checks: [
+      {
+        name: `${options.name}.frontmatter`,
+        status: hasFrontmatter && parseError === null ? 'pass' : 'fail',
+        message: frontmatterMessage,
+      },
+      {
+        name: `${options.name}.required_fields`,
+        status: hasFrontmatter && parseError === null && invalidRequiredFields.length === 0 ? 'pass' : 'fail',
+        message: requiredFieldsMessage,
+      },
+      {
+        name: `${options.name}.optional_steps`,
+        status: optionalStepsFieldValid && missingActivatedSteps.length === 0 ? 'pass' : 'fail',
+        message: optionalStepsMessage,
+      },
+      {
+        name: `${options.name}.checklist`,
+        status: checklistStatus,
+        message: checklistMessage,
+      },
+    ],
+  };
+}
+
 function normalizeLineEndings(content) {
   return String(content || '').replace(/\r\n?/g, '\n');
 }
@@ -515,6 +588,25 @@ function parseFrontmatter(content) {
     data,
     body: content.slice(match[0].length),
   };
+}
+
+function isValidFrontmatterField(value, type) {
+  if (type === 'string') {
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  if (type === 'string_or_date') {
+    return (
+      (typeof value === 'string' && value.trim().length > 0) ||
+      (value instanceof Date && !Number.isNaN(value.getTime()))
+    );
+  }
+
+  if (type === 'array') {
+    return Array.isArray(value);
+  }
+
+  return false;
 }
 
 function parseValue(rawValue) {

--- a/tests/tasks-validation-structure.test.mjs
+++ b/tests/tasks-validation-structure.test.mjs
@@ -1,0 +1,183 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { VerifyCommand } from '../dist/commands/VerifyCommand.js';
+import { services } from '../dist/services/index.js';
+
+const tempDirs = [];
+
+function trackTempDir(dirPath) {
+  tempDirs.push(dirPath);
+  return dirPath;
+}
+
+function findCheck(result, name) {
+  return result.checks.find(check => check.name === name);
+}
+
+async function writeText(filePath, content) {
+  await fs.ensureDir(path.dirname(filePath));
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+
+  while (tempDirs.length > 0) {
+    const dirPath = tempDirs.pop();
+    await fs.remove(dirPath);
+  }
+});
+
+describe('tasks and verification validation', () => {
+  it('fails tasks analysis when frontmatter is malformed', async () => {
+    const tempRoot = trackTempDir(await fs.mkdtemp(path.join(os.tmpdir(), 'ospec-tasks-validate-')));
+    const tasksPath = path.join(tempRoot, 'tasks.md');
+
+    await writeText(
+      tasksPath,
+      [
+        '---',
+        'feature: demo-change',
+        'created: 2026-04-04',
+        'optional_steps: [demo-step',
+        '---',
+        '## Task Checklist',
+        '- [ ] Implement the change',
+      ].join('\n')
+    );
+
+    const result = await services.projectService.analyzeChecklistDocument(tasksPath, 'tasks.md', []);
+
+    expect(result.checklistComplete).toBe(false);
+    expect(findCheck(result, 'tasks.md.frontmatter')).toMatchObject({ status: 'fail' });
+    expect(findCheck(result, 'tasks.md.required_fields')).toMatchObject({ status: 'fail' });
+    expect(findCheck(result, 'tasks.md.checklist')).toMatchObject({ status: 'fail' });
+  });
+
+  it('fails tasks analysis when checklist structure is rewritten away', async () => {
+    const tempRoot = trackTempDir(await fs.mkdtemp(path.join(os.tmpdir(), 'ospec-tasks-structure-')));
+    const tasksPath = path.join(tempRoot, 'tasks.md');
+
+    await writeText(
+      tasksPath,
+      [
+        '---',
+        'feature: demo-change',
+        'created: 2026-04-04',
+        'optional_steps: []',
+        '---',
+        '## Task Checklist',
+        '- 1. Implement the change',
+        '- 2. Run verification',
+      ].join('\n')
+    );
+
+    const result = await services.projectService.analyzeChecklistDocument(tasksPath, 'tasks.md', []);
+
+    expect(result.checklistComplete).toBe(false);
+    expect(findCheck(result, 'tasks.md.frontmatter')).toMatchObject({ status: 'pass' });
+    expect(findCheck(result, 'tasks.md.required_fields')).toMatchObject({ status: 'pass' });
+    expect(findCheck(result, 'tasks.md.checklist')).toMatchObject({ status: 'fail' });
+  });
+
+  it('fails verification analysis when checklist structure is missing', async () => {
+    const tempRoot = trackTempDir(await fs.mkdtemp(path.join(os.tmpdir(), 'ospec-verification-structure-')));
+    const verificationPath = path.join(tempRoot, 'verification.md');
+
+    await writeText(
+      verificationPath,
+      [
+        '---',
+        'feature: demo-change',
+        'created: 2026-04-04',
+        'status: verifying',
+        'optional_steps: []',
+        'passed_optional_steps: []',
+        '---',
+        '## Automated Checks',
+        '- build passed',
+        '- tests passed',
+      ].join('\n')
+    );
+
+    const result = await services.projectService.analyzeVerificationDocument(verificationPath, []);
+
+    expect(result.checklistComplete).toBe(false);
+    expect(findCheck(result, 'verification.md.frontmatter')).toMatchObject({ status: 'pass' });
+    expect(findCheck(result, 'verification.md.required_fields')).toMatchObject({ status: 'pass' });
+    expect(findCheck(result, 'verification.md.checklist')).toMatchObject({ status: 'fail' });
+  });
+
+  it('makes verify fail when tasks frontmatter is malformed', async () => {
+    const projectRoot = trackTempDir(await fs.mkdtemp(path.join(os.tmpdir(), 'ospec-verify-command-')));
+    const featureDir = path.join(projectRoot, 'changes', 'active', 'demo-change');
+
+    await fs.ensureDir(featureDir);
+    await fs.writeJson(
+      path.join(projectRoot, '.skillrc'),
+      await services.configManager.createDefaultConfig('full'),
+      { spaces: 2 }
+    );
+    await fs.writeJson(
+      path.join(featureDir, 'state.json'),
+      {
+        feature: 'demo-change',
+        status: 'verifying',
+        current_step: 'verification',
+        completed: [],
+        pending: [],
+        blocked_by: [],
+      },
+      { spaces: 2 }
+    );
+    await writeText(
+      path.join(featureDir, 'proposal.md'),
+      [
+        '---',
+        'name: demo-change',
+        'status: active',
+        'created: 2026-04-04',
+        'affects: []',
+        'flags: []',
+        '---',
+        '# Proposal',
+      ].join('\n')
+    );
+    await writeText(
+      path.join(featureDir, 'tasks.md'),
+      [
+        '---',
+        'feature: demo-change',
+        'created: 2026-04-04',
+        'optional_steps: [demo-step',
+        '---',
+        '## Task Checklist',
+        '- [ ] Implement the change',
+      ].join('\n')
+    );
+    await writeText(
+      path.join(featureDir, 'verification.md'),
+      [
+        '---',
+        'feature: demo-change',
+        'created: 2026-04-04',
+        'status: verifying',
+        'optional_steps: []',
+        'passed_optional_steps: []',
+        '---',
+        '## Automated Checks',
+        '- [x] build passed',
+      ].join('\n')
+    );
+
+    vi.spyOn(process, 'exit').mockImplementation(code => {
+      throw new Error(`process.exit:${code}`);
+    });
+
+    const command = new VerifyCommand();
+    await expect(command.execute(featureDir)).rejects.toThrow('process.exit:1');
+  });
+});


### PR DESCRIPTION
## Summary
- fail validation when tasks.md or verification.md frontmatter is missing or malformed
- require valid markdown checklist structure before treating checklist state as complete
- reuse the strict document analysis in verify and add regression coverage for malformed frontmatter and broken checklist structure

## Validation
- npx vitest run
- node scripts/release-smoke.js
- node dist/tools/build-index.js hook-check pre-commit (temp malformed tasks.md probe)

Fixes #6