### PR TITLE
Add hook-check regression coverage

### DIFF
--- a/tests/tasks-validation-structure.test.mjs
+++ b/tests/tasks-validation-structure.test.mjs
@@ -1,12 +1,14 @@
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
+import { spawnSync } from 'child_process';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { VerifyCommand } from '../dist/commands/VerifyCommand.js';
 import { services } from '../dist/services/index.js';
 
 const tempDirs = [];
+const buildIndexPath = path.resolve(process.cwd(), 'dist', 'tools', 'build-index.js');
 
 function trackTempDir(dirPath) {
   tempDirs.push(dirPath);
@@ -20,6 +22,19 @@ function findCheck(result, name) {
 async function writeText(filePath, content) {
   await fs.ensureDir(path.dirname(filePath));
   await fs.writeFile(filePath, content, 'utf8');
+}
+
+function runCommand(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed\n${result.stdout || ''}${result.stderr || ''}`);
+  }
+
+  return result;
 }
 
 afterEach(async () => {
@@ -179,5 +194,82 @@ describe('tasks and verification validation', () => {
 
     const command = new VerifyCommand();
     await expect(command.execute(featureDir)).rejects.toThrow('process.exit:1');
+  });
+
+  it('fails hook-check when staged tasks.md frontmatter is malformed', async () => {
+    const projectRoot = trackTempDir(await fs.mkdtemp(path.join(os.tmpdir(), 'ospec-hook-check-')));
+    const featureDir = path.join(projectRoot, 'changes', 'active', 'demo-change');
+    const config = await services.configManager.createDefaultConfig('full');
+
+    config.hooks['index-check'] = 'off';
+
+    await fs.ensureDir(featureDir);
+    await fs.writeJson(path.join(projectRoot, '.skillrc'), config, { spaces: 2 });
+    await fs.writeJson(
+      path.join(featureDir, 'state.json'),
+      {
+        feature: 'demo-change',
+        status: 'verifying',
+        current_step: 'verification',
+        completed: [],
+        pending: [],
+        blocked_by: [],
+      },
+      { spaces: 2 }
+    );
+    await writeText(
+      path.join(featureDir, 'proposal.md'),
+      [
+        '---',
+        'name: demo-change',
+        'status: active',
+        'created: 2026-04-04',
+        'affects: []',
+        'flags: []',
+        '---',
+        '# Proposal',
+      ].join('\n')
+    );
+    await writeText(
+      path.join(featureDir, 'tasks.md'),
+      [
+        '---',
+        'feature: demo-change',
+        'created: 2026-04-04',
+        'optional_steps: [demo-step',
+        '---',
+        '## Task Checklist',
+        '- [ ] Implement the change',
+      ].join('\n')
+    );
+    await writeText(
+      path.join(featureDir, 'verification.md'),
+      [
+        '---',
+        'feature: demo-change',
+        'created: 2026-04-04',
+        'status: verifying',
+        'optional_steps: []',
+        'passed_optional_steps: []',
+        '---',
+        '## Automated Checks',
+        '- [x] build passed',
+      ].join('\n')
+    );
+
+    runCommand('git', ['init'], projectRoot);
+    runCommand('git', ['config', 'user.name', 'Codex'], projectRoot);
+    runCommand('git', ['config', 'user.email', 'codex@example.com'], projectRoot);
+    runCommand('git', ['add', 'changes/active/demo-change/tasks.md'], projectRoot);
+
+    const result = spawnSync('node', [buildIndexPath, 'hook-check', 'pre-commit'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    });
+    const output = `${result.stdout || ''}${result.stderr || ''}`;
+
+    expect(result.status).toBe(1);
+    expect(output).toContain('tasks.md.frontmatter');
+    expect(output).toContain('hook blocked by current hook policy');
   });
 });


### PR DESCRIPTION
## Summary
- add a permanent regression test for the build-index hook-check path
- verify malformed tasks.md frontmatter now blocks the pre-commit summary as expected

## Validation
- npx vitest run